### PR TITLE
fix: monthly limit range validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,35 @@ jobs:
         run: cd .repo && npx projen package:js
       - name: Collect js Artifact
         run: mv .repo/dist dist
+  package-java:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: "! needs.build.outputs.self_mutation_happened"
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11.x
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create java artifact
+        run: cd .repo && npx projen package:java
+      - name: Collect java Artifact
+        run: mv .repo/dist dist
   package-python:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,46 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+  release_maven:
+    name: Publish to Maven Central
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11.x
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create java artifact
+        run: cd .repo && npx projen package:java
+      - name: Collect java Artifact
+        run: mv .repo/dist dist
+      - name: Release
+        env:
+          MAVEN_ENDPOINT: https://s01.oss.sonatype.org/
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
+        run: npx -p publib@latest publib-maven
   release_pypi:
     name: Publish to PyPI
     needs: release

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,6 +7,7 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+      - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
 pull_request_rules:
@@ -25,5 +26,6 @@ pull_request_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+      - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -138,6 +138,9 @@
           "spawn": "package:js"
         },
         {
+          "spawn": "package:java"
+        },
+        {
           "spawn": "package:python"
         },
         {
@@ -151,6 +154,15 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target dotnet"
+        }
+      ]
+    },
+    "package:java": {
+      "name": "package:java",
+      "description": "Create java language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --target java"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -50,11 +50,12 @@ const project = new awscdk.AwsCdkConstructLibrary({
     dotNetNamespace: "DataChef.CostMonitoringConstruct",
   },
   // Artifact config: Java
-  // publishToMaven: {
-  // mavenGroupId: 'co.datachef',
-  // javaPackage: 'co.datachef.costmonitoringconstruct',
-  // mavenArtifactId: 'costmonitoringconstruct',
-  // },
+  publishToMaven: {
+    javaPackage: "co.datachef.costmonitoringconstruct",
+    mavenArtifactId: "costmonitoringconstruct",
+    mavenGroupId: "co.datachef",
+    mavenEndpoint: "https://s01.oss.sonatype.org/",
+  },
   // TODO: add support for Go release.
   // Artifact config: Go
   //   publishToGo: {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:dotnet": "npx projen package:dotnet",
+    "package:java": "npx projen package:java",
     "package:js": "npx projen package:js",
     "package:python": "npx projen package:python",
     "post-compile": "npx projen post-compile",
@@ -112,6 +113,13 @@
   "jsii": {
     "outdir": "dist",
     "targets": {
+      "java": {
+        "package": "co.datachef.costmonitoringconstruct",
+        "maven": {
+          "groupId": "co.datachef",
+          "artifactId": "costmonitoringconstruct"
+        }
+      },
       "python": {
         "distName": "cost-monitoring-construct",
         "module": "cost_monitoring_construct"

--- a/src/application-cost-monitoring.ts
+++ b/src/application-cost-monitoring.ts
@@ -43,6 +43,13 @@ export class ApplicationCostMonitoring extends IBudgetStrategy {
    */
   constructor(stack: Stack, props: IApplicationCostMonitoringProps) {
     super(stack, props);
+
+    if (props.monthlyLimitInDollars < 30) {
+      throw RangeError(
+        "monthlyLimitInDollars must be greater than equal to 30."
+      );
+    }
+
     this.applicationName = props.applicationName;
     this.otherStacks = props.otherStacksIncludedInBudget ?? [];
   }

--- a/test/application-cost-monitoring.test.ts
+++ b/test/application-cost-monitoring.test.ts
@@ -25,6 +25,20 @@ describe("An ApplicationCostMonitoring", () => {
     subject = Template.fromStack(mockAppFirstStack);
   });
 
+  it("should throw range error if the monthly budget is less than $30", () => {
+    const mockApp = new App();
+    const mockAppFirstStack = new Stack(mockApp, "mocked-first-stack", {});
+
+    expect(() => {
+      new ApplicationCostMonitoring(mockAppFirstStack, {
+        applicationName: "mock-application",
+        monthlyLimitInDollars: 29,
+        defaultTopic: "mocked-topic",
+        subscribers: ["alert@example.com"],
+      });
+    }).toThrow(RangeError);
+  });
+
   it("should creates multiple aws budgets", () => {
     subject.resourceCountIs(AWSResourceType.Budget, 6);
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The default behavior of the `ApplicationCostMonitoring` for creating daily limits is to divide the provided monthly limit by 30. If the provided values is less than $30, then daily limit will be calculated as zero as they are integer values and does not accept floating points.

This pull request provide a validation for minimum valid value for the `monthlyLimitInDollars` parameter of the `ApplicationCostMonitoring` class. If the provided value is less than $30, it will throws a `RangeError`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Error 'budget limit must be larger than 0' even when specified](https://github.com/DataChefHQ/cost-monitoring-construct/issues/13
)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, there is no error preventing this issue form happening. As the CDK start to deploy the created constructs, AWS would throws a zero value budget error which does not informative.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A new test has also been added with this pull request to test if the validation throws a RangeError.