### PR TITLE
feat: custom cost allocation tag and python-compatibility fix

### DIFF
--- a/API.md
+++ b/API.md
@@ -311,13 +311,13 @@ Return default SNS topic only if the defultTopic prop has been passed when insta
 ```typescript
 import { ApplicationCostMonitoring } from 'cost-monitoring-construct'
 
-new ApplicationCostMonitoring(stack: Stack, props: IApplicationCostMonitoringProps)
+new ApplicationCostMonitoring(stack: Stack, props: ApplicationCostMonitoringProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoring.Initializer.parameter.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | - default stack to track its resources and it will be used to define Budget resources in it. |
-| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoring.Initializer.parameter.props">props</a></code> | <code><a href="#cost-monitoring-construct.IApplicationCostMonitoringProps">IApplicationCostMonitoringProps</a></code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoring.Initializer.parameter.props">props</a></code> | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps">ApplicationCostMonitoringProps</a></code> | *No description.* |
 
 ---
 
@@ -331,7 +331,7 @@ default stack to track its resources and it will be used to define Budget resour
 
 ##### `props`<sup>Required</sup> <a name="props" id="cost-monitoring-construct.ApplicationCostMonitoring.Initializer.parameter.props"></a>
 
-- *Type:* <a href="#cost-monitoring-construct.IApplicationCostMonitoringProps">IApplicationCostMonitoringProps</a>
+- *Type:* <a href="#cost-monitoring-construct.ApplicationCostMonitoringProps">ApplicationCostMonitoringProps</a>
 
 ---
 
@@ -441,6 +441,123 @@ public readonly applicationName: string;
 ```
 
 - *Type:* string
+
+---
+
+
+### ApplicationCostMonitoringProps <a name="ApplicationCostMonitoringProps" id="cost-monitoring-construct.ApplicationCostMonitoringProps"></a>
+
+- *Implements:* <a href="#cost-monitoring-construct.IApplicationCostMonitoringProps">IApplicationCostMonitoringProps</a>
+
+#### Initializers <a name="Initializers" id="cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer"></a>
+
+```typescript
+import { ApplicationCostMonitoringProps } from 'cost-monitoring-construct'
+
+new ApplicationCostMonitoringProps(applicationName: string, monthlyLimitInDollars: number, otherStacksIncludedInBudget?: Stack[], defaultTopic?: string, subscribers?: string[])
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.applicationName">applicationName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.monthlyLimitInDollars">monthlyLimitInDollars</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.otherStacksIncludedInBudget">otherStacksIncludedInBudget</a></code> | <code>aws-cdk-lib.Stack[]</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.defaultTopic">defaultTopic</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.subscribers">subscribers</a></code> | <code>string[]</code> | *No description.* |
+
+---
+
+##### `applicationName`<sup>Required</sup> <a name="applicationName" id="cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.applicationName"></a>
+
+- *Type:* string
+
+---
+
+##### `monthlyLimitInDollars`<sup>Required</sup> <a name="monthlyLimitInDollars" id="cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.monthlyLimitInDollars"></a>
+
+- *Type:* number
+
+---
+
+##### `otherStacksIncludedInBudget`<sup>Optional</sup> <a name="otherStacksIncludedInBudget" id="cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.otherStacksIncludedInBudget"></a>
+
+- *Type:* aws-cdk-lib.Stack[]
+
+---
+
+##### `defaultTopic`<sup>Optional</sup> <a name="defaultTopic" id="cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.defaultTopic"></a>
+
+- *Type:* string
+
+---
+
+##### `subscribers`<sup>Optional</sup> <a name="subscribers" id="cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.subscribers"></a>
+
+- *Type:* string[]
+
+---
+
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.applicationName">applicationName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.monthlyLimitInDollars">monthlyLimitInDollars</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.defaultTopic">defaultTopic</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.otherStacksIncludedInBudget">otherStacksIncludedInBudget</a></code> | <code>aws-cdk-lib.Stack[]</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.subscribers">subscribers</a></code> | <code>string[]</code> | *No description.* |
+
+---
+
+##### `applicationName`<sup>Required</sup> <a name="applicationName" id="cost-monitoring-construct.ApplicationCostMonitoringProps.property.applicationName"></a>
+
+```typescript
+public readonly applicationName: string;
+```
+
+- *Type:* string
+
+---
+
+##### `monthlyLimitInDollars`<sup>Required</sup> <a name="monthlyLimitInDollars" id="cost-monitoring-construct.ApplicationCostMonitoringProps.property.monthlyLimitInDollars"></a>
+
+```typescript
+public readonly monthlyLimitInDollars: number;
+```
+
+- *Type:* number
+
+---
+
+##### `defaultTopic`<sup>Optional</sup> <a name="defaultTopic" id="cost-monitoring-construct.ApplicationCostMonitoringProps.property.defaultTopic"></a>
+
+```typescript
+public readonly defaultTopic: string;
+```
+
+- *Type:* string
+
+---
+
+##### `otherStacksIncludedInBudget`<sup>Optional</sup> <a name="otherStacksIncludedInBudget" id="cost-monitoring-construct.ApplicationCostMonitoringProps.property.otherStacksIncludedInBudget"></a>
+
+```typescript
+public readonly otherStacksIncludedInBudget: Stack[];
+```
+
+- *Type:* aws-cdk-lib.Stack[]
+
+---
+
+##### `subscribers`<sup>Optional</sup> <a name="subscribers" id="cost-monitoring-construct.ApplicationCostMonitoringProps.property.subscribers"></a>
+
+```typescript
+public readonly subscribers: string[];
+```
+
+- *Type:* string[]
 
 ---
 
@@ -572,7 +689,7 @@ Return default SNS topic only if the defultTopic prop has been passed when insta
 
 - *Extends:* <a href="#cost-monitoring-construct.IBudgetStrategyProps">IBudgetStrategyProps</a>
 
-- *Implemented By:* <a href="#cost-monitoring-construct.IApplicationCostMonitoringProps">IApplicationCostMonitoringProps</a>
+- *Implemented By:* <a href="#cost-monitoring-construct.ApplicationCostMonitoringProps">ApplicationCostMonitoringProps</a>, <a href="#cost-monitoring-construct.IApplicationCostMonitoringProps">IApplicationCostMonitoringProps</a>
 
 
 #### Properties <a name="Properties" id="Properties"></a>
@@ -762,7 +879,7 @@ public readonly tags: ITag[];
 
 ### IBudgetStrategyProps <a name="IBudgetStrategyProps" id="cost-monitoring-construct.IBudgetStrategyProps"></a>
 
-- *Implemented By:* <a href="#cost-monitoring-construct.IApplicationCostMonitoringProps">IApplicationCostMonitoringProps</a>, <a href="#cost-monitoring-construct.IBudgetStrategyProps">IBudgetStrategyProps</a>
+- *Implemented By:* <a href="#cost-monitoring-construct.ApplicationCostMonitoringProps">ApplicationCostMonitoringProps</a>, <a href="#cost-monitoring-construct.IApplicationCostMonitoringProps">IApplicationCostMonitoringProps</a>, <a href="#cost-monitoring-construct.IBudgetStrategyProps">IBudgetStrategyProps</a>
 
 
 #### Properties <a name="Properties" id="Properties"></a>

--- a/API.md
+++ b/API.md
@@ -454,7 +454,7 @@ public readonly applicationName: string;
 ```typescript
 import { ApplicationCostMonitoringProps } from 'cost-monitoring-construct'
 
-new ApplicationCostMonitoringProps(applicationName: string, monthlyLimitInDollars: number, otherStacksIncludedInBudget?: Stack[], defaultTopic?: string, subscribers?: string[])
+new ApplicationCostMonitoringProps(applicationName: string, monthlyLimitInDollars: number, otherStacksIncludedInBudget?: Stack[], defaultTopic?: string, subscribers?: string[], costAllocationTag?: string)
 ```
 
 | **Name** | **Type** | **Description** |
@@ -464,6 +464,7 @@ new ApplicationCostMonitoringProps(applicationName: string, monthlyLimitInDollar
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.otherStacksIncludedInBudget">otherStacksIncludedInBudget</a></code> | <code>aws-cdk-lib.Stack[]</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.defaultTopic">defaultTopic</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.subscribers">subscribers</a></code> | <code>string[]</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.costAllocationTag">costAllocationTag</a></code> | <code>string</code> | *No description.* |
 
 ---
 
@@ -497,6 +498,12 @@ new ApplicationCostMonitoringProps(applicationName: string, monthlyLimitInDollar
 
 ---
 
+##### `costAllocationTag`<sup>Optional</sup> <a name="costAllocationTag" id="cost-monitoring-construct.ApplicationCostMonitoringProps.Initializer.parameter.costAllocationTag"></a>
+
+- *Type:* string
+
+---
+
 
 
 #### Properties <a name="Properties" id="Properties"></a>
@@ -505,6 +512,7 @@ new ApplicationCostMonitoringProps(applicationName: string, monthlyLimitInDollar
 | --- | --- | --- |
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.applicationName">applicationName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.monthlyLimitInDollars">monthlyLimitInDollars</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.costAllocationTag">costAllocationTag</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.defaultTopic">defaultTopic</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.otherStacksIncludedInBudget">otherStacksIncludedInBudget</a></code> | <code>aws-cdk-lib.Stack[]</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.ApplicationCostMonitoringProps.property.subscribers">subscribers</a></code> | <code>string[]</code> | *No description.* |
@@ -528,6 +536,16 @@ public readonly monthlyLimitInDollars: number;
 ```
 
 - *Type:* number
+
+---
+
+##### `costAllocationTag`<sup>Optional</sup> <a name="costAllocationTag" id="cost-monitoring-construct.ApplicationCostMonitoringProps.property.costAllocationTag"></a>
+
+```typescript
+public readonly costAllocationTag: string;
+```
+
+- *Type:* string
 
 ---
 
@@ -700,6 +718,7 @@ Return default SNS topic only if the defultTopic prop has been passed when insta
 | <code><a href="#cost-monitoring-construct.IApplicationCostMonitoringProps.property.defaultTopic">defaultTopic</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.IApplicationCostMonitoringProps.property.subscribers">subscribers</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.IApplicationCostMonitoringProps.property.applicationName">applicationName</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cost-monitoring-construct.IApplicationCostMonitoringProps.property.costAllocationTag">costAllocationTag</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cost-monitoring-construct.IApplicationCostMonitoringProps.property.otherStacksIncludedInBudget">otherStacksIncludedInBudget</a></code> | <code>aws-cdk-lib.Stack[]</code> | *No description.* |
 
 ---
@@ -738,6 +757,16 @@ public readonly subscribers: string[];
 
 ```typescript
 public readonly applicationName: string;
+```
+
+- *Type:* string
+
+---
+
+##### `costAllocationTag`<sup>Optional</sup> <a name="costAllocationTag" id="cost-monitoring-construct.IApplicationCostMonitoringProps.property.costAllocationTag"></a>
+
+```typescript
+public readonly costAllocationTag: string;
 ```
 
 - *Type:* string

--- a/src/application-cost-monitoring.ts
+++ b/src/application-cost-monitoring.ts
@@ -6,6 +6,7 @@ import { TimeUnit } from "./utils";
 export interface IApplicationCostMonitoringProps extends IBudgetStrategyProps {
   applicationName: string;
   otherStacksIncludedInBudget?: Stack[];
+  costAllocationTag?: string;
 }
 
 export class ApplicationCostMonitoringProps implements IApplicationCostMonitoringProps {
@@ -14,13 +15,15 @@ export class ApplicationCostMonitoringProps implements IApplicationCostMonitorin
     public monthlyLimitInDollars: number,
     public otherStacksIncludedInBudget?: Stack[],
     public defaultTopic?: string,
-    public subscribers?: string[]
+    public subscribers?: string[],
+    public costAllocationTag?: string
   ) {}
 }
 
 export class ApplicationCostMonitoring extends IBudgetStrategy {
   readonly applicationName: string;
   private otherStacks: Stack[];
+  private costAllocationTag?: string
 
   /**
    * Default Application CostMonitoring class that implements daily and monthly budgets.
@@ -31,6 +34,7 @@ export class ApplicationCostMonitoring extends IBudgetStrategy {
    * @param props.monthlyLimitInDollars - montly limit in US Dollors.
    * @param props.defaultTopic - default SNS topic name. Only if provided, the BudgetStratgy creates an SNS topic and send notifications to it.
    * @param props.subscribers - list of email address that the CostMonitoring will use to send alerts to.
+   * @param props.costAllocationTag - Tag key used to track resources' expenditure. Only if provided, it will be used to tag the application resources.
    *
    * @example tracking budget for an application called `my-application`:
    * const app = new cdk.App();
@@ -62,6 +66,7 @@ export class ApplicationCostMonitoring extends IBudgetStrategy {
 
     this.applicationName = props.applicationName;
     this.otherStacks = props.otherStacksIncludedInBudget ?? [];
+    this.costAllocationTag = props.costAllocationTag;
   }
 
   protected createDailyBudgets(
@@ -143,6 +148,6 @@ export class ApplicationCostMonitoring extends IBudgetStrategy {
    * Default key name for application tag.
    */
   protected get applicationTagKey(): string {
-    return "cm:application";
+    return this.costAllocationTag || "cm:application";
   }
 }

--- a/src/application-cost-monitoring.ts
+++ b/src/application-cost-monitoring.ts
@@ -8,6 +8,16 @@ export interface IApplicationCostMonitoringProps extends IBudgetStrategyProps {
   otherStacksIncludedInBudget?: Stack[];
 }
 
+export class ApplicationCostMonitoringProps implements IApplicationCostMonitoringProps {
+  constructor(
+    public applicationName: string,
+    public monthlyLimitInDollars: number,
+    public otherStacksIncludedInBudget?: Stack[],
+    public defaultTopic?: string,
+    public subscribers?: string[]
+  ) {}
+}
+
 export class ApplicationCostMonitoring extends IBudgetStrategy {
   readonly applicationName: string;
   private otherStacks: Stack[];
@@ -41,7 +51,7 @@ export class ApplicationCostMonitoring extends IBudgetStrategy {
    * budgetStratgy.monitor();
    *
    */
-  constructor(stack: Stack, props: IApplicationCostMonitoringProps) {
+  constructor(stack: Stack, props: ApplicationCostMonitoringProps) {
     super(stack, props);
 
     if (props.monthlyLimitInDollars < 30) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { AccountCostMonitoring } from "./account-cost-monitoring";
 export {
   ApplicationCostMonitoring,
+  ApplicationCostMonitoringProps,
   IApplicationCostMonitoringProps,
 } from "./application-cost-monitoring";
 export * from "./budget-strategy";


### PR DESCRIPTION
## Description
This PR introduces 2 things:

1. Allow the user to specify the cost allocation tag key.
2. Fixes the interface issues that came up with the Python version of this package. (see #20)

## Related Issue
See #20 

## Motivation and Context
1. This is needed because Cost Allocation Tags must be enabled before they can be used. However, this is only possible from the Management / Billing AWS account. It's not possible from child accounts. This change allows the user to specify their own tag key, so they can use what their organization allows as Cost Allocation Tags.
2. Is needed because using this construct with python required some weird ass shenanigans that were very counter-intuitive. This fixes it.

## How Has This Been Tested?
In my own AWS Sandbox account
